### PR TITLE
feat(ci): migrate to ci v1

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
     secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
     secrets: inherit
     with:
-      rock-name: pilot
+      rock-name: istio-pilot-discovery

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -15,4 +15,4 @@ jobs:
     uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
     secrets: inherit
     with:
-      rock-name: istio-pilot-discovery
+      rock-name: istio-pilot

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
     secrets: inherit
     with:
-      rock-name: pilot
+      rock-name: istio-pilot-discovery

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -11,4 +11,4 @@ jobs:
     uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
     secrets: inherit
     with:
-      rock-name: istio-pilot-discovery
+      rock-name: istio-pilot

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v1
     with:
-      rock-name: pilot
+      rock-name: istio-pilot-discovery
       source-repo: istio/istio
       check-go: true
     secrets: inherit

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     uses: canonical/observability/.github/workflows/rock-update.yaml@v1
     with:
-      rock-name: istio-pilot-discovery
+      rock-name: istio-pilot
       source-repo: istio/istio
       check-go: true
     secrets: inherit

--- a/1.23.3/rockcraft.yaml
+++ b/1.23.3/rockcraft.yaml
@@ -1,6 +1,6 @@
 # Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
 
-name: pilot
+name: istio-pilot-discovery
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
 version: "1.23.3"
@@ -19,7 +19,7 @@ platforms:
 
 parts:
   # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
-  pilot-discovery:
+  istio-pilot-discovery:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
@@ -36,7 +36,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - pilot-discovery
+      - istio-pilot-discovery
       - ca-certs
     override-prime: |
       set -x

--- a/1.23.3/rockcraft.yaml
+++ b/1.23.3/rockcraft.yaml
@@ -1,6 +1,6 @@
 # Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
 
-name: istio-pilot-discovery
+name: istio-pilot
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
 version: "1.23.3"
@@ -19,7 +19,7 @@ platforms:
 
 parts:
   # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
-  istio-pilot-discovery:
+  istio-pilot:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
@@ -36,7 +36,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - istio-pilot-discovery
+      - istio-pilot
       - ca-certs
     override-prime: |
       set -x

--- a/1.24.3/rockcraft.yaml
+++ b/1.24.3/rockcraft.yaml
@@ -1,6 +1,6 @@
 # Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
 
-name: istio-pilot-discovery
+name: istio-pilot
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
 version: "1.24.3"
@@ -19,7 +19,7 @@ platforms:
 
 parts:
   # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
-  istio-pilot-discovery:
+  istio-pilot:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
@@ -36,7 +36,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - istio-pilot-discovery
+      - istio-pilot
       - ca-certs
     override-prime: |
       set -x

--- a/1.26.1/rockcraft.yaml
+++ b/1.26.1/rockcraft.yaml
@@ -3,7 +3,7 @@
 name: istio-pilot-discovery
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
-version: "1.24.3"
+version: "1.26.1"
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 services:
@@ -23,9 +23,9 @@ parts:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
-    source-tag: "1.24.3"
+    source-tag: "1.26.1"
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     override-build: |
       GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=vtprotobuf,disable_pgv ./pilot/cmd/pilot-discovery
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin

--- a/1.26.1/rockcraft.yaml
+++ b/1.26.1/rockcraft.yaml
@@ -1,6 +1,6 @@
 # Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
 
-name: istio-pilot-discovery
+name: istio-pilot
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
 version: "1.26.1"
@@ -19,7 +19,7 @@ platforms:
 
 parts:
   # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
-  istio-pilot-discovery:
+  istio-pilot:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
@@ -36,7 +36,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - istio-pilot-discovery
+      - istio-pilot
       - ca-certs
     override-prime: |
       set -x

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set quiet # Recipes are silent by default
 set export # Just variables are exported to environment variables
 
-rock_name := `echo ${PWD##*/} | sed 's/^istio-//;s/-rock//'`
+rock_name := `awk '/^name:/{print $2}' */rockcraft.yaml | head -1`
 latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
 
 [private]


### PR DESCRIPTION
## Issue
Migrates ci to v1

And
i. Fixes the rock naming - the names were mismatching between the rock-name used in the ci, the rock name used in the rockcraft.yaml and the part name used in the OCI image. This was basically causing all the rock workflows to fail (informed guess, looking at the central ci files since we dont have any workflow logs anymore since its been forever since any of the workflows ran) It is now all standardized and matches the upstream artificat name with the istio- prefix.
ii. Adds a rock for v1.26.1 which is what the current charms are using
