### PR TITLE
fix: istiod expects a non root user

### DIFF
--- a/1.29.0/rockcraft.yaml
+++ b/1.29.0/rockcraft.yaml
@@ -12,6 +12,7 @@ services:
     command: /usr/local/bin/pilot-discovery [ ]
     override: replace
     startup: enabled
+run-user: _daemon_
 entrypoint-service: pilot-discovery
 platforms:
   amd64:


### PR DESCRIPTION
## Issue
istiod expects to run as a non-root user or else the container wont start. this fixes this issue.
