### PR TITLE
chore: rollback baseimage

### DIFF
--- a/1.29.0/rockcraft.yaml
+++ b/1.29.0/rockcraft.yaml
@@ -1,12 +1,12 @@
 # Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
-# This rock is based on the `ubuntu@26.04` rock and includes the `ca-certificates` package for secure communication. The `pilot-discovery` service is configured to run the Pilot component of Istio's service mesh, which is responsible for managing and configuring the Envoy proxies that handle traffic within the mesh. The rock also includes a `deb-security-manifest` part that generates a manifest of installed packages and their versions for security auditing purposes.
+# This rock is based on the `ubuntu@24.04` rock and includes the `ca-certificates` package for secure communication. The `pilot-discovery` service is configured to run the Pilot component of Istio's service mesh, which is responsible for managing and configuring the Envoy proxies that handle traffic within the mesh. The rock also includes a `deb-security-manifest` part that generates a manifest of installed packages and their versions for security auditing purposes.
 
 name: istio-pilot
 summary: Istio's pilot in a rock
 description: "Pilot: The core component of Istio's service mesh"
 version: "1.29.0"
-base: ubuntu@26.04
-build-base: ubuntu@26.04
+base: ubuntu@24.04
+build-base: ubuntu@24.04
 services:
   pilot-discovery:
     command: /usr/local/bin/pilot-discovery [ ]


### PR DESCRIPTION
rollsback v1.29 to ubuntu 2404 baseimage
